### PR TITLE
export syntax fix

### DIFF
--- a/src/bjorklund.js
+++ b/src/bjorklund.js
@@ -75,4 +75,4 @@ function euclideanPattern(onsets, pulses) {
 // console.log(euclideanPattern(3,8)); // [ 1,0,0,1,0,0,1,0 ] //
 ////////////////////////////////////////////////////////////////
 
-module.export = { euclideanPattern }
+module.exports = { euclideanPattern }

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,3 @@
-const euclideanPattern = require( "./bjorklund" );
+const { euclideanPattern } = require( "./bjorklund" );
 
-module.export = { euclideanPattern };
+module.exports = { euclideanPattern };


### PR DESCRIPTION
# Correccion de sintaxis te export 

Habia un error en export debia ser `exports` esto corrige y lo puedes llamar al importar asi:
```
const {euclideanPattern} = require('rtg-music')
console.log(euclideanPattern(1, 2))
```